### PR TITLE
components: standards-table: link to status IRI

### DIFF
--- a/components/standards-table/standards-table.vue
+++ b/components/standards-table/standards-table.vue
@@ -87,13 +87,13 @@
           </p>
         </td>
         <td>
-          <p>
+          <a :href="standard?.status" :target="_blank">
             {{
               !!standard?.status
                 ? getStatusFromUrl(standard?.status, $t)
                 : Usage.TBD
             }}
-          </p>
+          </a>
         </td>
         <td>
           <div


### PR DESCRIPTION
The meaning of a certain specification status can be read now when clicked on the status.